### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 # - docker inspect oracle
 # - docker ps -a
 - echo "Wait to allow Oracle to be initialized"
-- travis_wait sleep 10
+- sleep 10
 - docker top oracle
 - docker exec -it mysql mysql -u root -p'my-secret-pw' -s -e "create database dba;create database dbb;create database dbc;"
 install: mvn install -DskipTests -Dgpg.skip


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
